### PR TITLE
Improve mindist performance

### DIFF
--- a/src/bourgan/embed.py
+++ b/src/bourgan/embed.py
@@ -58,11 +58,8 @@ def mindist(x_id, idxset, distmat):
     Returns:
         mindist (float): minimal distance
     """
-    mindist = np.inf
-    for y_id in idxset[0]:
-        d = distmat[x_id, y_id]
-        if d < mindist:
-            mindist = d
-    if mindist == np.inf:
-        mindist = 0
-    return mindist
+    d = distmat[x_id, idxset[0]]
+    if d.shape[0] == 0:
+        return 0
+    else:
+        return np.min(d)


### PR DESCRIPTION
Hello a554b554,

I think there is a performance bottleneck in calculating minimum distance. This PR use Numpy matrix operation instead of a python loop will bring significant performance improvements.

It takes 8 minutes to calculate a (20000, 256) matrix in the original program, but using this method takes only about 50 seconds to complete.